### PR TITLE
Replace panicking with raising a Python exception

### DIFF
--- a/src/rust/lib.rs
+++ b/src/rust/lib.rs
@@ -243,20 +243,20 @@ fn svg_to_bytes(
         if let Some(svg_path) = svg_path {
             if std::path::Path::new(&svg_path).exists() {
                 let mut svg_data =
-                    std::fs::read(&svg_path).expect("failed to open the provided file");
+                    std::fs::read(&svg_path).map_err(|_e| PyErr::new::<PyValueError, _>("failed to open the provided file"))?;
                 if svg_data.starts_with(&[0x1f, 0x8b]) {
                     svg_data = resvg::usvg::decompress_svgz(&svg_data)
-                        .expect("can't decompress the svg file");
+                        .map_err(|_e| PyErr::new::<PyValueError, _>("can't decompress the svg file"))?;
                 };
                 _svg_string = std::str::from_utf8(&svg_data)
-                    .expect("can't convert bytes to utf-8")
+                    .map_err(|_e| PyErr::new::<PyValueError, _>("can't convert bytes to utf-8"))?
                     .to_owned();
             }
         }
     }
 
     if _svg_string.is_empty() {
-        panic!("`svg_string` is empty or `svg_path` contains empty invalid svg");
+        return Err(PyErr::new::<PyValueError, _>("`svg_string` is empty or `svg_path` contains empty invalid svg"));
     }
 
     let mut fit_to = FitTo::Original;
@@ -275,34 +275,37 @@ fn svg_to_bytes(
         fit_to = FitTo::Zoom(z as f32);
     }
 
-    let _shape_rendering = match shape_rendering
+    let _shape_rendering_opt = match shape_rendering
         .unwrap_or("geometric_precision".to_string())
         .as_ref()
     {
-        "optimize_speed" => resvg::usvg::ShapeRendering::OptimizeSpeed,
-        "crisp_edges" => resvg::usvg::ShapeRendering::CrispEdges,
-        "geometric_precision" => resvg::usvg::ShapeRendering::GeometricPrecision,
-        _ => panic!("Unexpected invalid token for shape rendering"),
+        "optimize_speed" => Some(resvg::usvg::ShapeRendering::OptimizeSpeed),
+        "crisp_edges" => Some(resvg::usvg::ShapeRendering::CrispEdges),
+        "geometric_precision" => Some(resvg::usvg::ShapeRendering::GeometricPrecision),
+        _ => None,
     };
+    let _shape_rendering = _shape_rendering_opt.ok_or(PyErr::new::<PyValueError, _>("Unexpected invalid token for shape rendering"))?;
 
-    let _text_rendering = match text_rendering
+    let _text_rendering_opt = match text_rendering
         .unwrap_or("optimize_legibility".to_string())
         .as_ref()
     {
-        "optimize_speed" => resvg::usvg::TextRendering::OptimizeSpeed,
-        "optimize_legibility" => resvg::usvg::TextRendering::OptimizeLegibility,
-        "geometric_precision" => resvg::usvg::TextRendering::GeometricPrecision,
-        _ => panic!("Unexpected invalid token for text rendering"),
+        "optimize_speed" => Some(resvg::usvg::TextRendering::OptimizeSpeed),
+        "optimize_legibility" => Some(resvg::usvg::TextRendering::OptimizeLegibility),
+        "geometric_precision" => Some(resvg::usvg::TextRendering::GeometricPrecision),
+        _ => None,
     };
+    let _text_rendering = _text_rendering_opt.ok_or(PyErr::new::<PyValueError, _>("Unexpected invalid token for text rendering"))?;
 
-    let _image_rendering = match image_rendering
+    let _image_rendering_opt = match image_rendering
         .unwrap_or("optimize_quality".to_string())
         .as_ref()
     {
-        "optimize_quality" => resvg::usvg::ImageRendering::OptimizeQuality,
-        "optimize_speed" => resvg::usvg::ImageRendering::OptimizeSpeed,
-        _ => panic!("Unexpected invalid token for image rendering",),
+        "optimize_quality" => Some(resvg::usvg::ImageRendering::OptimizeQuality),
+        "optimize_speed" => Some(resvg::usvg::ImageRendering::OptimizeSpeed),
+        _ => None,
     };
+    let _image_rendering = _image_rendering_opt.ok_or(PyErr::new::<PyValueError, _>("Unexpected invalid token for image rendering"))?;
 
     let _resources_dir = match resources_dir {
         Some(value) => Some(std::fs::canonicalize(value)?),
@@ -312,7 +315,7 @@ fn svg_to_bytes(
     let _background = match background {
         Some(color_str) => match color_str.parse::<svgtypes::Color>() {
             Ok(color) => Some(color),
-            Err(error) => panic!("Error background: {}", error),
+            Err(_error) => None,
         },
         None => None,
     };


### PR DESCRIPTION
Some parts of the code were panicking, which could crash the entire Python interpreter. A possible improvement could be to propagate these errors to Python, raising a `ValueError` instead.