### PR TITLE
fix: prevent invalid input from aborting Python

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -410,7 +410,7 @@ dependencies = [
 
 [[package]]
 name = "resvg_py"
-version = "0.3.4"
+version = "0.4.0"
 dependencies = [
  "log",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ opt-level = 'z'
 strip = true
 
 [profile.release]
-panic = "abort"
+# PyO3 can only translate Rust panics into Python exceptions when they unwind.
 codegen-units = 1
 lto = "fat"
 opt-level = 'z'

--- a/docs/exceptions.rst
+++ b/docs/exceptions.rst
@@ -3,8 +3,11 @@ Exceptions
 
 .. currentmodule:: resvg_py
 
-All errors from ``resvg_py`` surface as :py:exc:`ValueError`. Below is every
-scenario, the exact message, and how to avoid it.
+The input and rendering failures described below surface as
+:py:exc:`ValueError`. Python argument conversion can raise :py:exc:`TypeError`
+or :py:exc:`OverflowError`; other filesystem options can raise subclasses of
+:py:exc:`OSError`. An unforeseen unwinding Rust panic is translated by PyO3
+into ``pyo3_runtime.PanicException`` instead of terminating the interpreter.
 
 Invalid SVG input
 -----------------
@@ -17,7 +20,18 @@ Raised when:
 
 * ``svg_string`` is ``None``, ``""``, or only whitespace.
 * ``svg_path`` points to a file that is empty, missing, or contains no valid SVG.
-* A ``.svgz`` file fails to decompress.
+
+File loading errors
+-------------------
+
+Failures while reading or decoding an existing ``svg_path`` include the path
+and the underlying error:
+
+.. code-block:: text
+
+   ValueError: Failed to read '<path>': <OS error>
+   ValueError: Failed to decompress '<path>': <gzip error>
+   ValueError: '<path>' is not valid UTF-8: <UTF-8 error>
 
 .. tip::
 
@@ -77,6 +91,18 @@ Raised when the ``background`` string cannot be parsed as a CSS color by the
       >>> resvg_py.svg_to_bytes(svg_string=svg, background="not-a-color")
       ValueError: Error background: ...
 
+Invalid numeric values
+----------------------
+
+``width`` and ``height`` accept positive integers up to ``2**32 - 1``; zero
+raises ``ValueError``, while values outside the accepted integer type fail
+during Python argument conversion. After argument conversion, a supplied
+dimension takes precedence over ``zoom`` value validation and scaling; zoom is
+used only when both dimensions are absent. When used, ``zoom`` and
+``font_size`` must be positive finite numbers; ``dpi`` must be a non-negative
+finite number. Invalid values handled by ``svg_to_bytes`` raise ``ValueError``
+naming the parameter and constraint.
+
 Rendering / processing errors
 -----------------------------
 
@@ -86,7 +112,7 @@ encoding is raised as ``ValueError`` with the underlying Rust error message.
 Common causes:
 
 * Malformed XML (unclosed tags, invalid namespaces)
-* Dimensions that are zero or exceed the platform's maximum pixmap size
+* Dimensions that exceed the platform's maximum pixmap size
 * Out-of-memory during PNG encoding
 
 .. code-block:: python
@@ -95,9 +121,8 @@ Common causes:
 
 .. danger::
 
-   Extremely large ``width`` / ``height`` or ``zoom`` values can cause an
-   ``OutOfMemory`` panic at the Rust level. Keep dimensions under 32767 pixels
-   per side.
+   Extremely large ``width`` / ``height`` or ``zoom`` values can exhaust process
+   memory. Keep dimensions under 32767 pixels per side.
 
 .. seealso::
 

--- a/src/rust/lib.rs
+++ b/src/rust/lib.rs
@@ -334,9 +334,9 @@ fn svg_to_bytes(
     font_files: Option<Vec<String>>,
     font_dirs: Option<Vec<String>>,
     // Effects based
-    shape_rendering: Option<String>,
-    text_rendering: Option<String>,
-    image_rendering: Option<String>,
+    shape_rendering: String,
+    text_rendering: String,
+    image_rendering: String,
 ) -> PyResult<Vec<u8>> {
     if log_information.unwrap_or(false) {
         START.call_once(|| {
@@ -394,13 +394,17 @@ fn svg_to_bytes(
         && let Some(svg_path) = svg_path
         && std::path::Path::new(&svg_path).exists()
     {
-        let mut svg_data = std::fs::read(&svg_path).expect("failed to open the provided file");
+        let mut svg_data = std::fs::read(&svg_path)
+            .map_err(|e| PyValueError::new_err(format!("Failed to read '{}': {}", svg_path, e)))?;
         if svg_data.starts_with(&[0x1f, 0x8b]) {
-            svg_data =
-                resvg::usvg::decompress_svgz(&svg_data).expect("can't decompress the svg file");
+            svg_data = resvg::usvg::decompress_svgz(&svg_data).map_err(|e| {
+                PyValueError::new_err(format!("Failed to decompress '{}': {}", svg_path, e))
+            })?;
         };
         _svg_string = std::str::from_utf8(&svg_data)
-            .expect("can't convert bytes to utf-8")
+            .map_err(|e| {
+                PyValueError::new_err(format!("'{}' is not valid UTF-8: {}", svg_path, e))
+            })?
             .to_owned();
     }
 
@@ -413,14 +417,34 @@ fn svg_to_bytes(
     let mut fit_to = FitTo::Original;
     let mut default_size = resvg::usvg::Size::from_wh(100.0, 100.0).unwrap();
 
+    let positive_dimension = |name: &str, value: u32| {
+        if value == 0 {
+            Err(PyValueError::new_err(format!(
+                "The value of '{}' must be a positive integer",
+                name
+            )))
+        } else {
+            Ok(value as f32)
+        }
+    };
+
     if let (Some(w), Some(h)) = (width, height) {
-        default_size = resvg::usvg::Size::from_wh(w as f32, h as f32).unwrap();
+        let (w_f, h_f) = (
+            positive_dimension("width", w)?,
+            positive_dimension("height", h)?,
+        );
+        default_size = resvg::usvg::Size::from_wh(w_f, h_f)
+            .ok_or_else(|| PyValueError::new_err("Failed to build a size from 'width'/'height'"))?;
         fit_to = FitTo::Size(w, h);
     } else if let Some(w) = width {
-        default_size = resvg::usvg::Size::from_wh(w as f32, 100.0).unwrap();
+        let w_f = positive_dimension("width", w)?;
+        default_size = resvg::usvg::Size::from_wh(w_f, 100.0)
+            .ok_or_else(|| PyValueError::new_err("Failed to build a size from 'width'"))?;
         fit_to = FitTo::Width(w);
     } else if let Some(h) = height {
-        default_size = resvg::usvg::Size::from_wh(100.0, h as f32).unwrap();
+        let h_f = positive_dimension("height", h)?;
+        default_size = resvg::usvg::Size::from_wh(100.0, h_f)
+            .ok_or_else(|| PyValueError::new_err("Failed to build a size from 'height'"))?;
         fit_to = FitTo::Height(h);
     } else if let Some(z) = zoom {
         if !z.is_finite() || z <= 0.0 {
@@ -445,40 +469,37 @@ fn svg_to_bytes(
         ));
     }
 
-    let shape_rendering_val = shape_rendering.unwrap();
-    let _shape_rendering = match shape_rendering_val.as_ref() {
+    let _shape_rendering = match shape_rendering.as_ref() {
         "optimize_speed" => resvg::usvg::ShapeRendering::OptimizeSpeed,
         "crisp_edges" => resvg::usvg::ShapeRendering::CrispEdges,
         "geometric_precision" => resvg::usvg::ShapeRendering::GeometricPrecision,
         _ => {
             return Err(PyValueError::new_err(format!(
                 "The value of 'shape_rendering' must be one of 'optimize_speed','crisp_edges','geometric_precision'.It is currently '{}'",
-                shape_rendering_val
+                shape_rendering
             )));
         }
     };
 
-    let text_rendering_val = text_rendering.unwrap();
-    let _text_rendering = match text_rendering_val.as_ref() {
+    let _text_rendering = match text_rendering.as_ref() {
         "optimize_speed" => resvg::usvg::TextRendering::OptimizeSpeed,
         "optimize_legibility" => resvg::usvg::TextRendering::OptimizeLegibility,
         "geometric_precision" => resvg::usvg::TextRendering::GeometricPrecision,
         _ => {
             return Err(PyValueError::new_err(format!(
                 "The value of 'text_rendering' must be one of 'optimize_speed','optimize_legibility','geometric_precision'. It is currently '{}'",
-                text_rendering_val
+                text_rendering
             )));
         }
     };
 
-    let image_rendering_val = image_rendering.unwrap();
-    let _image_rendering = match image_rendering_val.as_ref() {
+    let _image_rendering = match image_rendering.as_ref() {
         "optimize_quality" => resvg::usvg::ImageRendering::OptimizeQuality,
         "optimize_speed" => resvg::usvg::ImageRendering::OptimizeSpeed,
         _ => {
             return Err(PyValueError::new_err(format!(
                 "The value of 'image_rendering' must be one of 'optimize_quality','optimize_speed'. It is currently '{}'",
-                image_rendering_val
+                image_rendering
             )));
         }
     };

--- a/tests/exception/test_exception.py
+++ b/tests/exception/test_exception.py
@@ -1,6 +1,10 @@
 import pytest
 import resvg_py
 
+
+SVG = '<svg xmlns="http://www.w3.org/2000/svg" width="4" height="4"/>'
+
+
 def test_broken_svg_raises_exception():
     broken_svg = """<svg xmlns="http://www.w3.org/2000/svg" width=1194" height="240" viewBox="0 0 1194">
     <g>
@@ -10,3 +14,9 @@ def test_broken_svg_raises_exception():
     
     with pytest.raises(ValueError):
         resvg_py.svg_to_bytes(svg_string=broken_svg)
+
+
+@pytest.mark.parametrize("argument", ["shape_rendering", "text_rendering", "image_rendering"])
+def test_rendering_policy_none_raises_type_error(argument):
+    with pytest.raises(TypeError):
+        resvg_py.svg_to_bytes(svg_string=SVG, **{argument: None})

--- a/tests/path/test_path.py
+++ b/tests/path/test_path.py
@@ -4,6 +4,7 @@ import os
 
 from pathlib import Path
 
+import pytest
 import resvg_py
 
 BASE_DIR = Path(__file__).resolve().parent
@@ -22,3 +23,30 @@ def test_gzip_path():
     path = os.path.join(BASE_DIR, "acid.svg.gz")
     base = base64.b64encode(bytes(resvg_py.svg_to_bytes(svg_path=path))).decode("utf-8")
     assert base == _expected["acid"]
+
+
+def test_corrupt_gzip_raises_value_error(tmp_path):
+    path = tmp_path / "corrupt.svgz"
+    path.write_bytes(b"\x1f\x8bnot gzip")
+
+    with pytest.raises(ValueError) as exc_info:
+        resvg_py.svg_to_bytes(svg_path=str(path))
+    assert str(exc_info.value).startswith(f"Failed to decompress '{path}':")
+
+
+def test_non_utf8_file_raises_value_error(tmp_path):
+    path = tmp_path / "non-utf8.svg"
+    path.write_bytes(b"\xff\xfe")
+
+    with pytest.raises(ValueError) as exc_info:
+        resvg_py.svg_to_bytes(svg_path=str(path))
+    assert str(exc_info.value).startswith(f"'{path}' is not valid UTF-8:")
+
+
+def test_unreadable_path_raises_value_error(tmp_path):
+    path = tmp_path / "directory.svg"
+    path.mkdir()
+
+    with pytest.raises(ValueError) as exc_info:
+        resvg_py.svg_to_bytes(svg_path=str(path))
+    assert str(exc_info.value).startswith(f"Failed to read '{path}':")

--- a/tests/shape/test_float_options.py
+++ b/tests/shape/test_float_options.py
@@ -36,6 +36,44 @@ def test_float_dpi_and_font_size_are_accepted():
         ("font_size", math.inf),
     ],
 )
-def test_invalid_float_options_raise_value_error(argument, value):
+def test_invalid_numeric_options_raise_value_error(argument, value):
     with pytest.raises(ValueError):
         resvg_py.svg_to_bytes(svg_string=SVG, **{argument: value})
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"width": 0},
+        {"height": 0},
+        {"width": 0, "height": 1},
+        {"width": 1, "height": 0},
+    ],
+)
+def test_zero_dimension_raises_value_error(kwargs):
+    with pytest.raises(ValueError):
+        resvg_py.svg_to_bytes(svg_string=SVG, **kwargs)
+
+
+@pytest.mark.parametrize("argument", ["width", "height"])
+@pytest.mark.parametrize("value", [-1, 2**32])
+def test_dimension_outside_u32_raises_overflow_error(argument, value):
+    with pytest.raises(OverflowError):
+        resvg_py.svg_to_bytes(svg_string=SVG, **{argument: value})
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "expected_size"),
+    [
+        ({"width": 50, "zoom": math.nan}, (50, 40)),
+        ({"height": 40, "zoom": math.nan}, (50, 40)),
+        ({"width": 30, "height": 20, "zoom": math.nan}, (25, 20)),
+    ],
+)
+def test_dimension_takes_precedence_over_zoom(kwargs, expected_size):
+    assert png_size(bytes(resvg_py.svg_to_bytes(svg_string=SVG, **kwargs))) == expected_size
+
+
+def test_arguments_are_converted_before_dimension_precedence():
+    with pytest.raises(TypeError):
+        resvg_py.svg_to_bytes(svg_string=SVG, width=50, zoom="invalid")


### PR DESCRIPTION
## Summary

- Raise catchable Python exceptions for zero dimensions, unreadable or malformed SVG files, and invalid rendering-policy types.
- Let unforeseen unwinding Rust panics reach PyO3 instead of aborting the host interpreter.

## Why

In 0.4.0, `width=0`, `shape_rendering=None`, or an existing unreadable `svg_path` terminates Python with exit 134. Embedding applications cannot recover without isolating rendering in a subprocess. This completes the exception-safety direction established by #82 and #92.

Fixes #169.

## Design

Known caller and file failures are handled at the boundary; normal PyO3 conversion errors retain their Python types. Panic unwinding is defense in depth, not the mechanism used for known cases. On macOS arm64, the abi3 wheel grows by 67,096 bytes (5.84%).

## Test plan

- Reproduced all three process aborts against the published 0.4.0 wheel.
- Verified the same calls return `ValueError`, `TypeError`, and `ValueError` from a release build.
- `uv run pytest -q .` (40 passed, 1 skipped)
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- Sphinx HTML build (one pre-existing missing `_static` warning)
