### PR TITLE
ci: validate release wheels before publishing

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -270,7 +270,7 @@ jobs:
           pattern: wheels-linux-x86_64-*
           path: wheels
           merge-multiple: true
-      - uses: astral-sh/setup-uv@v10.0.0
+      - uses: astral-sh/setup-uv@v10.0.1
         with:
           enable-cache: false
       - name: List built wheels
@@ -299,7 +299,7 @@ jobs:
           pattern: wheels-windows-x64-*
           path: wheels
           merge-multiple: true
-      - uses: astral-sh/setup-uv@v10.0.0
+      - uses: astral-sh/setup-uv@v10.0.1
         with:
           enable-cache: false
       - name: List built wheels
@@ -343,7 +343,7 @@ jobs:
           python-version: ${{ matrix.python }}
           architecture: arm64
           allow-prereleases: true
-      - uses: astral-sh/setup-uv@v10.0.0
+      - uses: astral-sh/setup-uv@v10.0.1
         with:
           enable-cache: false
       - name: List built wheels
@@ -371,7 +371,7 @@ jobs:
           pattern: wheels-macos-aarch64-*
           path: wheels
           merge-multiple: true
-      - uses: astral-sh/setup-uv@v10.0.0
+      - uses: astral-sh/setup-uv@v10.0.1
         with:
           enable-cache: false
       - name: List built wheels
@@ -461,7 +461,7 @@ jobs:
           subject-path: 'wheels-*/*'
       - name: Install uv
         if: ${{ startsWith(github.ref, 'refs/tags/') }}
-        uses: astral-sh/setup-uv@v10.0.0
+        uses: astral-sh/setup-uv@v10.0.1
       - name: Publish to PyPI
         if: ${{ startsWith(github.ref, 'refs/tags/') }}
         run: uv publish 'wheels-*/*'

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -280,10 +280,9 @@ jobs:
         run: |
           for py in 3.10 3.11 3.12 3.13 3.14 3.14t 3.15 3.15t pypy3.11; do
             echo "::group::$py"
-            uv venv --python "$py" ".venv-$py"
+            UV_PROJECT_ENVIRONMENT=".venv-$py" uv sync --only-group test --python "$py"
             VIRTUAL_ENV=".venv-$py" uv pip install --only-binary :all: --no-index --find-links wheels resvg_py
-            VIRTUAL_ENV=".venv-$py" uv pip install pytest pyperclip
-            VIRTUAL_ENV=".venv-$py" uv run --no-project pytest tests -q
+            UV_PROJECT_ENVIRONMENT=".venv-$py" uv run --no-sync pytest -v -x -rs
             echo "::endgroup::"
           done
 
@@ -312,10 +311,9 @@ jobs:
         run: |
           for py in 3.10 3.11 3.12 3.13 3.14 3.14t 3.15 3.15t; do
             echo "::group::$py"
-            uv venv --python "$py" ".venv-$py"
+            UV_PROJECT_ENVIRONMENT=".venv-$py" uv sync --only-group test --python "$py"
             VIRTUAL_ENV=".venv-$py" uv pip install --only-binary :all: --no-index --find-links wheels resvg_py
-            VIRTUAL_ENV=".venv-$py" uv pip install pytest pyperclip
-            VIRTUAL_ENV=".venv-$py" uv run --no-project pytest tests -q
+            UV_PROJECT_ENVIRONMENT=".venv-$py" uv run --no-sync pytest -v -x -rs
             echo "::endgroup::"
           done
 
@@ -353,10 +351,9 @@ jobs:
         run: ls -l wheels
       - name: Install and test target runtime
         run: |
-          uv venv --python python .venv-target
+          UV_PROJECT_ENVIRONMENT=.venv-target uv sync --only-group test --python python
           VIRTUAL_ENV=.venv-target uv pip install --only-binary :all: --no-index --find-links wheels resvg_py
-          VIRTUAL_ENV=.venv-target uv pip install pytest pyperclip
-          VIRTUAL_ENV=.venv-target uv run --no-project pytest tests -q
+          UV_PROJECT_ENVIRONMENT=.venv-target uv run --no-sync pytest -v -x -rs
 
   wheel-coverage-macos:
     name: wheel coverage (macos arm64 target runtimes)
@@ -380,10 +377,9 @@ jobs:
         run: |
           for py in 3.10 3.11 3.12 3.13 3.14 3.14t 3.15 3.15t; do
             echo "::group::$py"
-            uv venv --python "$py" ".venv-$py"
+            UV_PROJECT_ENVIRONMENT=".venv-$py" uv sync --only-group test --python "$py"
             VIRTUAL_ENV=".venv-$py" uv pip install --only-binary :all: --no-index --find-links wheels resvg_py
-            VIRTUAL_ENV=".venv-$py" uv pip install pytest pyperclip
-            VIRTUAL_ENV=".venv-$py" uv run --no-project pytest tests -q
+            UV_PROJECT_ENVIRONMENT=".venv-$py" uv run --no-sync pytest -v -x -rs
             echo "::endgroup::"
           done
 

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -32,7 +32,7 @@ jobs:
     name: linux ${{ matrix.platform.target }} ${{ matrix.abi.name }}
     runs-on: ${{ matrix.platform.runner }}
     # Advisory until every manylinux image ships python3.15t; only x86_64/i686 have it today.
-    continue-on-error: ${{ matrix.abi.tag == 'abi3t' }}
+    continue-on-error: ${{ matrix.abi.tag == 'abi3t' && !startsWith(github.ref, 'refs/tags/') }}
     strategy:
       fail-fast: false
       matrix:
@@ -72,7 +72,7 @@ jobs:
   musllinux:
     name: musllinux ${{ matrix.platform.target }} ${{ matrix.abi.name }}
     runs-on: ${{ matrix.platform.runner }}
-    continue-on-error: ${{ matrix.abi.tag == 'abi3t' }}
+    continue-on-error: ${{ matrix.abi.tag == 'abi3t' && !startsWith(github.ref, 'refs/tags/') }}
     strategy:
       fail-fast: false
       matrix:
@@ -108,7 +108,7 @@ jobs:
   windows:
     name: windows ${{ matrix.platform.target }} ${{ matrix.abi.name }}
     runs-on: ${{ matrix.platform.runner }}
-    continue-on-error: ${{ matrix.abi.tag == 'abi3t' }}
+    continue-on-error: ${{ matrix.abi.tag == 'abi3t' && !startsWith(github.ref, 'refs/tags/') }}
     strategy:
       fail-fast: false
       matrix:
@@ -149,7 +149,7 @@ jobs:
   macos:
     name: macos ${{ matrix.platform.target }} ${{ matrix.abi.name }}
     runs-on: ${{ matrix.platform.runner }}
-    continue-on-error: ${{ matrix.abi.tag == 'abi3t' }}
+    continue-on-error: ${{ matrix.abi.tag == 'abi3t' && !startsWith(github.ref, 'refs/tags/') }}
     strategy:
       fail-fast: false
       matrix:
@@ -280,7 +280,7 @@ jobs:
           for py in 3.10 3.11 3.12 3.13 3.14 3.14t 3.15 3.15t pypy3.11; do
             echo "::group::$py"
             uv venv --python "$py" ".venv-$py"
-            VIRTUAL_ENV=".venv-$py" uv pip install --no-index --find-links wheels resvg_py
+            VIRTUAL_ENV=".venv-$py" uv pip install --only-binary :all: --no-index --find-links wheels resvg_py
             VIRTUAL_ENV=".venv-$py" uv pip install pytest pyperclip
             VIRTUAL_ENV=".venv-$py" uv run --no-project pytest tests -q
             echo "::endgroup::"
@@ -312,7 +312,7 @@ jobs:
             Write-Output "::group::$py"
             $env:VIRTUAL_ENV = ".venv-$py"
             uv venv --python $py $env:VIRTUAL_ENV
-            uv pip install --no-index --find-links wheels resvg_py
+            uv pip install --only-binary :all: --no-index --find-links wheels resvg_py
             uv pip install pytest pyperclip
             uv run --no-project pytest tests -q
             Remove-Item Env:VIRTUAL_ENV
@@ -354,7 +354,7 @@ jobs:
           $PSNativeCommandUseErrorActionPreference = $true
           uv venv --python python .venv-target
           $env:VIRTUAL_ENV = ".venv-target"
-          uv pip install --no-index --find-links wheels resvg_py
+          uv pip install --only-binary :all: --no-index --find-links wheels resvg_py
           uv pip install pytest pyperclip
           uv run --no-project pytest tests -q
 
@@ -381,7 +381,7 @@ jobs:
           for py in 3.10 3.11 3.12 3.13 3.14 3.14t 3.15 3.15t; do
             echo "::group::$py"
             uv venv --python "$py" ".venv-$py"
-            VIRTUAL_ENV=".venv-$py" uv pip install --no-index --find-links wheels resvg_py
+            VIRTUAL_ENV=".venv-$py" uv pip install --only-binary :all: --no-index --find-links wheels resvg_py
             VIRTUAL_ENV=".venv-$py" uv pip install pytest pyperclip
             VIRTUAL_ENV=".venv-$py" uv run --no-project pytest tests -q
             echo "::endgroup::"
@@ -408,6 +408,53 @@ jobs:
       attestations: write
     steps:
       - uses: actions/download-artifact@v8
+      - name: Verify release artifact inventory
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+
+          assert_one_wheel() {
+            local artifact=$1
+            local wheels=("$artifact"/*.whl)
+            if [[ ${#wheels[@]} -ne 1 ]]; then
+              echo "::error::$artifact must contain exactly one wheel; found ${#wheels[@]}"
+              ls -la "$artifact" || true
+              exit 1
+            fi
+          }
+
+          for target in x86_64 x86 aarch64 armv7 s390x ppc64le; do
+            for abi in abi3 cp314t abi3t pypy311; do
+              assert_one_wheel "wheels-linux-$target-$abi"
+            done
+          done
+          for target in x86_64 x86 aarch64 armv7; do
+            for abi in abi3 cp314t abi3t pypy311; do
+              assert_one_wheel "wheels-musllinux-$target-$abi"
+            done
+          done
+          for target in x64 x86 aarch64; do
+            for abi in abi3 cp314t abi3t; do
+              assert_one_wheel "wheels-windows-$target-$abi"
+            done
+          done
+          for target in x86_64 aarch64; do
+            for abi in abi3 cp314t abi3t; do
+              assert_one_wheel "wheels-macos-$target-$abi"
+            done
+          done
+          for target in aarch64-linux-android x86_64-linux-android; do
+            assert_one_wheel "wheels-android-$target"
+          done
+
+          sdists=(wheels-sdist/*.tar.gz)
+          wheels=(wheels-*/*.whl)
+          release_files=(wheels-*/*)
+          if [[ ${#wheels[@]} -ne 57 || ${#sdists[@]} -ne 1 || ${#release_files[@]} -ne 58 ]]; then
+            echo "::error::expected exactly 57 wheels and one sdist; found ${#wheels[@]} wheels, ${#sdists[@]} sdists, and ${#release_files[@]} total files"
+            exit 1
+          fi
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v4
         with:

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -280,9 +280,9 @@ jobs:
         run: |
           for py in 3.10 3.11 3.12 3.13 3.14 3.14t 3.15 3.15t pypy3.11; do
             echo "::group::$py"
-            UV_PROJECT_ENVIRONMENT=".venv-$py" uv sync --only-group test --python "$py"
-            VIRTUAL_ENV=".venv-$py" uv pip install --only-binary :all: --no-index --find-links wheels resvg_py
-            UV_PROJECT_ENVIRONMENT=".venv-$py" uv run --no-sync pytest -v -x -rs
+            uv sync --only-group test --python "$py"
+            uv pip install --only-binary :all: --no-index --find-links wheels resvg_py
+            uv run --no-sync pytest -v -x -rs
             echo "::endgroup::"
           done
 
@@ -311,9 +311,9 @@ jobs:
         run: |
           for py in 3.10 3.11 3.12 3.13 3.14 3.14t 3.15 3.15t; do
             echo "::group::$py"
-            UV_PROJECT_ENVIRONMENT=".venv-$py" uv sync --only-group test --python "$py"
-            VIRTUAL_ENV=".venv-$py" uv pip install --only-binary :all: --no-index --find-links wheels resvg_py
-            UV_PROJECT_ENVIRONMENT=".venv-$py" uv run --no-sync pytest -v -x -rs
+            uv sync --only-group test --python "$py"
+            uv pip install --only-binary :all: --no-index --find-links wheels resvg_py
+            uv run --no-sync pytest -v -x -rs
             echo "::endgroup::"
           done
 
@@ -351,9 +351,9 @@ jobs:
         run: ls -l wheels
       - name: Install and test target runtime
         run: |
-          UV_PROJECT_ENVIRONMENT=.venv-target uv sync --only-group test --python python
-          VIRTUAL_ENV=.venv-target uv pip install --only-binary :all: --no-index --find-links wheels resvg_py
-          UV_PROJECT_ENVIRONMENT=.venv-target uv run --no-sync pytest -v -x -rs
+          uv sync --only-group test --python python
+          uv pip install --only-binary :all: --no-index --find-links wheels resvg_py
+          uv run --no-sync pytest -v -x -rs
 
   wheel-coverage-macos:
     name: wheel coverage (macos arm64 target runtimes)
@@ -377,9 +377,9 @@ jobs:
         run: |
           for py in 3.10 3.11 3.12 3.13 3.14 3.14t 3.15 3.15t; do
             echo "::group::$py"
-            UV_PROJECT_ENVIRONMENT=".venv-$py" uv sync --only-group test --python "$py"
-            VIRTUAL_ENV=".venv-$py" uv pip install --only-binary :all: --no-index --find-links wheels resvg_py
-            UV_PROJECT_ENVIRONMENT=".venv-$py" uv run --no-sync pytest -v -x -rs
+            uv sync --only-group test --python "$py"
+            uv pip install --only-binary :all: --no-index --find-links wheels resvg_py
+            uv run --no-sync pytest -v -x -rs
             echo "::endgroup::"
           done
 

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -255,26 +255,29 @@ jobs:
         with:
           name: wheels-sdist
           path: dist
-  # Installs with --no-index so wheel-tag selection picks the wheel: a dropped leg or a mis-tagged
-  # wheel fails here rather than at a user's `pip install`.
-  abi-coverage:
-    name: abi coverage (one wheel set, every interpreter)
+  # Install the built wheels with --no-index: build interpreters select the ABI family, while these
+  # target interpreters prove the emitted tags and runtime compatibility on each desktop platform.
+  wheel-coverage-linux:
+    name: wheel coverage (linux x86_64 target runtimes)
     needs: [linux]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - uses: actions/download-artifact@v8
         with:
           pattern: wheels-linux-x86_64-*
           path: wheels
           merge-multiple: true
       - uses: astral-sh/setup-uv@v10.0.0
+        with:
+          enable-cache: false
       - name: List built wheels
         run: ls -l wheels
-      - name: Install and run the test suite on every interpreter
-        # 3.15/3.15t omitted: the abi3t leg is advisory, so its wheel may not be present.
+      - name: Install and test every target runtime
         run: |
-          for py in 3.10 3.11 3.12 3.13 3.14 3.14t pypy3.11; do
+          for py in 3.10 3.11 3.12 3.13 3.14 3.14t 3.15 3.15t pypy3.11; do
             echo "::group::$py"
             uv venv --python "$py" ".venv-$py"
             VIRTUAL_ENV=".venv-$py" uv pip install --no-index --find-links wheels resvg_py
@@ -283,34 +286,79 @@ jobs:
             echo "::endgroup::"
           done
 
-  test:
-      needs: [linux, musllinux, windows, macos, android, sdist]
-      name: Run Tests
-      runs-on: windows-latest
-      strategy:
-        matrix:
-          python-version:
-            - '3.10'
-            - '3.11'
-            - '3.12'
-            - '3.13'
-            - '3.14'
-      steps:
-        - uses: actions/checkout@v7
-        - name: Set up Python (uv)
-          uses: astral-sh/setup-uv@v10.0.0
-        - name: Create virtual environment and install dependencies
-          run: |
-            uv sync
-        - name: Run backend tests
-          run: |
-            uv run pytest -v -x -rs
+  wheel-coverage-windows:
+    name: wheel coverage (windows x64 target runtimes)
+    needs: [windows]
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - uses: actions/download-artifact@v8
+        with:
+          pattern: wheels-windows-x64-*
+          path: wheels
+          merge-multiple: true
+      - uses: astral-sh/setup-uv@v10.0.0
+        with:
+          enable-cache: false
+      - name: List built wheels
+        run: Get-ChildItem wheels
+      - name: Install and test every target runtime
+        shell: pwsh
+        run: |
+          $PSNativeCommandUseErrorActionPreference = $true
+          foreach ($py in @("3.10", "3.11", "3.12", "3.13", "3.14", "3.14t", "3.15", "3.15t")) {
+            Write-Output "::group::$py"
+            $env:VIRTUAL_ENV = ".venv-$py"
+            uv venv --python $py $env:VIRTUAL_ENV
+            uv pip install --no-index --find-links wheels resvg_py
+            uv pip install pytest pyperclip
+            uv run --no-project pytest tests -q
+            Remove-Item Env:VIRTUAL_ENV
+            Write-Output "::endgroup::"
+          }
+
+  wheel-coverage-macos:
+    name: wheel coverage (macos arm64 target runtimes)
+    needs: [macos]
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - uses: actions/download-artifact@v8
+        with:
+          pattern: wheels-macos-aarch64-*
+          path: wheels
+          merge-multiple: true
+      - uses: astral-sh/setup-uv@v10.0.0
+        with:
+          enable-cache: false
+      - name: List built wheels
+        run: ls -l wheels
+      - name: Install and test every target runtime
+        run: |
+          for py in 3.10 3.11 3.12 3.13 3.14 3.14t 3.15 3.15t; do
+            echo "::group::$py"
+            uv venv --python "$py" ".venv-$py"
+            VIRTUAL_ENV=".venv-$py" uv pip install --no-index --find-links wheels resvg_py
+            VIRTUAL_ENV=".venv-$py" uv pip install pytest pyperclip
+            VIRTUAL_ENV=".venv-$py" uv run --no-project pytest tests -q
+            echo "::endgroup::"
+          done
 
   release:
     name: Release
     runs-on: ubuntu-latest
     if: ${{ startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch' }}
-    needs: [test, abi-coverage]
+    needs:
+      - wheel-coverage-linux
+      - wheel-coverage-windows
+      - wheel-coverage-macos
+      - musllinux
+      - android
+      - sdist
     permissions:
       # Use to sign the release artifacts
       id-token: write

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -31,8 +31,6 @@ jobs:
   linux:
     name: linux ${{ matrix.platform.target }} ${{ matrix.abi.name }}
     runs-on: ${{ matrix.platform.runner }}
-    # Advisory until every manylinux image ships python3.15t; only x86_64/i686 have it today.
-    continue-on-error: ${{ matrix.abi.tag == 'abi3t' && !startsWith(github.ref, 'refs/tags/') }}
     strategy:
       fail-fast: false
       matrix:
@@ -67,12 +65,12 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: wheels-linux-${{ matrix.platform.target }}-${{ matrix.abi.tag }}
-          path: dist
+          path: dist/*.whl
+          if-no-files-found: error
 
   musllinux:
     name: musllinux ${{ matrix.platform.target }} ${{ matrix.abi.name }}
     runs-on: ${{ matrix.platform.runner }}
-    continue-on-error: ${{ matrix.abi.tag == 'abi3t' && !startsWith(github.ref, 'refs/tags/') }}
     strategy:
       fail-fast: false
       matrix:
@@ -103,12 +101,12 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: wheels-musllinux-${{ matrix.platform.target }}-${{ matrix.abi.tag }}
-          path: dist
+          path: dist/*.whl
+          if-no-files-found: error
 
   windows:
     name: windows ${{ matrix.platform.target }} ${{ matrix.abi.name }}
     runs-on: ${{ matrix.platform.runner }}
-    continue-on-error: ${{ matrix.abi.tag == 'abi3t' && !startsWith(github.ref, 'refs/tags/') }}
     strategy:
       fail-fast: false
       matrix:
@@ -144,12 +142,12 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: wheels-windows-${{ matrix.platform.target }}-${{ matrix.abi.tag }}
-          path: dist
+          path: dist/*.whl
+          if-no-files-found: error
 
   macos:
     name: macos ${{ matrix.platform.target }} ${{ matrix.abi.name }}
     runs-on: ${{ matrix.platform.runner }}
-    continue-on-error: ${{ matrix.abi.tag == 'abi3t' && !startsWith(github.ref, 'refs/tags/') }}
     strategy:
       fail-fast: false
       matrix:
@@ -178,7 +176,8 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: wheels-macos-${{ matrix.platform.target }}-${{ matrix.abi.tag }}
-          path: dist
+          path: dist/*.whl
+          if-no-files-found: error
 
   # emscripten:
   #   runs-on: ${{ matrix.platform.runner }}
@@ -239,7 +238,8 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: wheels-android-${{ matrix.platform.target }}
-          path: dist
+          path: dist/*.whl
+          if-no-files-found: error
 
   sdist:
     runs-on: ubuntu-latest
@@ -254,7 +254,8 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: wheels-sdist
-          path: dist
+          path: dist/*.tar.gz
+          if-no-files-found: error
   # Install the built wheels with --no-index: build interpreters select the ABI family, while these
   # target interpreters prove the emitted tags and runtime compatibility on each desktop platform.
   wheel-coverage-linux:
@@ -290,6 +291,9 @@ jobs:
     name: wheel coverage (windows x64 target runtimes)
     needs: [windows]
     runs-on: windows-latest
+    defaults:
+      run:
+        shell: bash
     steps:
       - uses: actions/checkout@v7
         with:
@@ -303,26 +307,25 @@ jobs:
         with:
           enable-cache: false
       - name: List built wheels
-        run: Get-ChildItem wheels
+        run: ls -l wheels
       - name: Install and test every target runtime
-        shell: pwsh
         run: |
-          $PSNativeCommandUseErrorActionPreference = $true
-          foreach ($py in @("3.10", "3.11", "3.12", "3.13", "3.14", "3.14t", "3.15", "3.15t")) {
-            Write-Output "::group::$py"
-            $env:VIRTUAL_ENV = ".venv-$py"
-            uv venv --python $py $env:VIRTUAL_ENV
-            uv pip install --only-binary :all: --no-index --find-links wheels resvg_py
-            uv pip install pytest pyperclip
-            uv run --no-project pytest tests -q
-            Remove-Item Env:VIRTUAL_ENV
-            Write-Output "::endgroup::"
-          }
+          for py in 3.10 3.11 3.12 3.13 3.14 3.14t 3.15 3.15t; do
+            echo "::group::$py"
+            uv venv --python "$py" ".venv-$py"
+            VIRTUAL_ENV=".venv-$py" uv pip install --only-binary :all: --no-index --find-links wheels resvg_py
+            VIRTUAL_ENV=".venv-$py" uv pip install pytest pyperclip
+            VIRTUAL_ENV=".venv-$py" uv run --no-project pytest tests -q
+            echo "::endgroup::"
+          done
 
   wheel-coverage-windows-arm64:
     name: wheel coverage (windows arm64 Python ${{ matrix.python }})
     needs: [windows]
     runs-on: windows-11-arm
+    defaults:
+      run:
+        shell: bash
     strategy:
       fail-fast: false
       matrix:
@@ -347,16 +350,13 @@ jobs:
         with:
           enable-cache: false
       - name: List built wheels
-        run: Get-ChildItem wheels
+        run: ls -l wheels
       - name: Install and test target runtime
-        shell: pwsh
         run: |
-          $PSNativeCommandUseErrorActionPreference = $true
           uv venv --python python .venv-target
-          $env:VIRTUAL_ENV = ".venv-target"
-          uv pip install --only-binary :all: --no-index --find-links wheels resvg_py
-          uv pip install pytest pyperclip
-          uv run --no-project pytest tests -q
+          VIRTUAL_ENV=.venv-target uv pip install --only-binary :all: --no-index --find-links wheels resvg_py
+          VIRTUAL_ENV=.venv-target uv pip install pytest pyperclip
+          VIRTUAL_ENV=.venv-target uv run --no-project pytest tests -q
 
   wheel-coverage-macos:
     name: wheel coverage (macos arm64 target runtimes)
@@ -390,7 +390,7 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    if: ${{ startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch' }}
+    if: ${{ startsWith(github.ref, 'refs/tags/') }}
     needs:
       - wheel-coverage-linux
       - wheel-coverage-windows
@@ -408,63 +408,18 @@ jobs:
       attestations: write
     steps:
       - uses: actions/download-artifact@v8
-      - name: Verify release artifact inventory
-        shell: bash
-        run: |
-          set -euo pipefail
-          shopt -s nullglob
-
-          assert_one_wheel() {
-            local artifact=$1
-            local wheels=("$artifact"/*.whl)
-            if [[ ${#wheels[@]} -ne 1 ]]; then
-              echo "::error::$artifact must contain exactly one wheel; found ${#wheels[@]}"
-              ls -la "$artifact" || true
-              exit 1
-            fi
-          }
-
-          for target in x86_64 x86 aarch64 armv7 s390x ppc64le; do
-            for abi in abi3 cp314t abi3t pypy311; do
-              assert_one_wheel "wheels-linux-$target-$abi"
-            done
-          done
-          for target in x86_64 x86 aarch64 armv7; do
-            for abi in abi3 cp314t abi3t pypy311; do
-              assert_one_wheel "wheels-musllinux-$target-$abi"
-            done
-          done
-          for target in x64 x86 aarch64; do
-            for abi in abi3 cp314t abi3t; do
-              assert_one_wheel "wheels-windows-$target-$abi"
-            done
-          done
-          for target in x86_64 aarch64; do
-            for abi in abi3 cp314t abi3t; do
-              assert_one_wheel "wheels-macos-$target-$abi"
-            done
-          done
-          for target in aarch64-linux-android x86_64-linux-android; do
-            assert_one_wheel "wheels-android-$target"
-          done
-
-          sdists=(wheels-sdist/*.tar.gz)
-          wheels=(wheels-*/*.whl)
-          release_files=(wheels-*/*)
-          if [[ ${#wheels[@]} -ne 57 || ${#sdists[@]} -ne 1 || ${#release_files[@]} -ne 58 ]]; then
-            echo "::error::expected exactly 57 wheels and one sdist; found ${#wheels[@]} wheels, ${#sdists[@]} sdists, and ${#release_files[@]} total files"
-            exit 1
-          fi
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v4
         with:
-          subject-path: 'wheels-*/*'
+          subject-path: |
+            wheels-*/*.whl
+            wheels-sdist/*.tar.gz
       - name: Install uv
         if: ${{ startsWith(github.ref, 'refs/tags/') }}
         uses: astral-sh/setup-uv@v10.0.1
       - name: Publish to PyPI
         if: ${{ startsWith(github.ref, 'refs/tags/') }}
-        run: uv publish 'wheels-*/*'
+        run: uv publish 'wheels-*/*.whl' 'wheels-sdist/*.tar.gz'
         env:
           UV_PUBLISH_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
       - name: Upload to GitHub Release

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -319,6 +319,45 @@ jobs:
             Write-Output "::endgroup::"
           }
 
+  wheel-coverage-windows-arm64:
+    name: wheel coverage (windows arm64 Python ${{ matrix.python }})
+    needs: [windows]
+    runs-on: windows-11-arm
+    strategy:
+      fail-fast: false
+      matrix:
+        # Windows ARM64 has no native CPython 3.10 runtime.
+        python: ["3.11", "3.12", "3.13", "3.14", "3.14t", "3.15", "3.15t"]
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - uses: actions/download-artifact@v8
+        with:
+          pattern: wheels-windows-aarch64-*
+          path: wheels
+          merge-multiple: true
+      # uv has no native managed-Python downloads for Windows ARM64, so pin the target explicitly.
+      - uses: actions/setup-python@v7
+        with:
+          python-version: ${{ matrix.python }}
+          architecture: arm64
+          allow-prereleases: true
+      - uses: astral-sh/setup-uv@v10.0.0
+        with:
+          enable-cache: false
+      - name: List built wheels
+        run: Get-ChildItem wheels
+      - name: Install and test target runtime
+        shell: pwsh
+        run: |
+          $PSNativeCommandUseErrorActionPreference = $true
+          uv venv --python python .venv-target
+          $env:VIRTUAL_ENV = ".venv-target"
+          uv pip install --no-index --find-links wheels resvg_py
+          uv pip install pytest pyperclip
+          uv run --no-project pytest tests -q
+
   wheel-coverage-macos:
     name: wheel coverage (macos arm64 target runtimes)
     needs: [macos]
@@ -355,6 +394,7 @@ jobs:
     needs:
       - wheel-coverage-linux
       - wheel-coverage-windows
+      - wheel-coverage-windows-arm64
       - wheel-coverage-macos
       - musllinux
       - android


### PR DESCRIPTION
Closes #171.

## Summary

- Test downloaded wheels on their native target runtimes, including GIL/free-threaded CPython and
  Linux PyPy.
- Require every build family to emit a typed distribution, and keep release mutation tag-only.

## Why and design

For stable-ABI legs, PyO3 Cargo features set the minimum runtime. Build interpreters select the
wheel family and tag; target runtimes validate forward compatibility.

Each runtime check syncs the repository's `test` group without installing the project, installs
`resvg_py` only from downloaded wheels, then runs pytest without resyncing. Neither PyPI nor the
source checkout can mask an incompatible artifact.

The workflow matrix is the output contract: abi3t is required like every other family, while extension-specific uploads fail when a build emits no distribution. This follows future matrix changes without maintaining a second census.

CPython 3.10–3.15 plus 3.14t/3.15t run on Linux x86_64, Windows x64, and macOS ARM64; Linux also
tests PyPy 3.11. Native Windows ARM64 begins at 3.11. Other targets remain build-and-upload gated.

## Validation

- PR run `32054631582` at `89eaad5`: 68 checks passed; `Release` skipped.
- Local workflow, Bash, and lockfile checks passed at `89eaad5`; Rust formatting and Clippy passed
  before the two workflow-only follow-ups.
- Branch-dispatch run `32001109975` at `687a990`: passed; `Release` skipped.
