### PR TITLE
release: prepare 0.5.0

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -403,6 +403,16 @@ jobs:
       # Used to generate artifact attestation
       attestations: write
     steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - name: Verify tag matches the package version
+        run: |
+          package_version=$(cargo metadata --locked --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "resvg_py") | .version')
+          if [ "$GITHUB_REF_NAME" != "$package_version" ]; then
+            echo "::error::tag '$GITHUB_REF_NAME' does not match Cargo.toml version '$package_version'"
+            exit 1
+          fi
       - uses: actions/download-artifact@v8
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -410,7 +410,7 @@ dependencies = [
 
 [[package]]
 name = "resvg_py"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "log",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "resvg_py"
 version = "0.5.0"
 edition = "2024"
-authors = ['baseplate-admin', 'Sergei Iakhnitskii']
+authors = ['baseplate-admin']
 build = 'build.rs'
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "resvg_py"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
-authors = ['baseplate-admin']
+authors = ['baseplate-admin', 'Sergei Iakhnitskii']
 build = 'build.rs'
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -8,13 +8,13 @@ Module attributes
 
 .. data:: __version__
 
-   :iconify:`mdi:tag` Package version string, e.g. ``"0.3.2"``.
+   :iconify:`mdi:tag` Package version string, e.g. ``"1.2.3"``.
 
    :type: str
 
 .. data:: __author__
 
-   :iconify:`mdi:account` Package author.
+   :iconify:`mdi:account` Colon-separated package authors from the Cargo metadata.
 
    :type: str
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -14,7 +14,7 @@ Module attributes
 
 .. data:: __author__
 
-   :iconify:`mdi:account` Colon-separated package authors from the Cargo metadata.
+   :iconify:`mdi:account` Package author.
 
    :type: str
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -26,7 +26,7 @@ Requirements
 
 .. important::
 
-   Python **3.10** through **3.14** is supported. Python 3.9 wheels are no
+   Python **3.10** through **3.15** is supported. Python 3.9 wheels are no
    longer built -- upgrade your interpreter or install from source.
 
 Install
@@ -122,10 +122,11 @@ Verify installation
 .. code-block:: python
 
    >>> import resvg_py
-   >>> resvg_py.__version__
-   '0.3.2'
-   >>> resvg_py.__resvg_version__
-   '0.47.0'
+   >>> from importlib.metadata import version
+   >>> resvg_py.__version__ == version("resvg_py")
+   True
+   >>> isinstance(resvg_py.__resvg_version__, str)
+   True
 
 Install from source
 -------------------
@@ -154,5 +155,4 @@ If no wheel is available for your platform, build from source with
       .. code-block:: bash
 
          uv pip install git+https://github.com/baseplate-admin/resvg-py.git
-
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ name = "resvg_py"
 dynamic = ["version"]
 authors = [
     { name = "baseplate-admin", email = "61817579+baseplate-admin@users.noreply.github.com" },
+    { name = "Sergei Iakhnitskii" },
 ]
 classifiers = [
     "Programming Language :: Rust",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,6 @@ name = "resvg_py"
 dynamic = ["version"]
 authors = [
     { name = "baseplate-admin", email = "61817579+baseplate-admin@users.noreply.github.com" },
-    { name = "Sergei Iakhnitskii" },
 ]
 classifiers = [
     "Programming Language :: Rust",

--- a/tests/version/test_version.py
+++ b/tests/version/test_version.py
@@ -1,5 +1,11 @@
+from importlib.metadata import version
+
 import resvg_py
 
 
-def test_version_is_string():
-    assert isinstance(resvg_py.__version__,str)  
+def test_version_matches_distribution_metadata():
+    assert resvg_py.__version__ == version("resvg_py")
+
+
+def test_resvg_version_is_string():
+    assert isinstance(resvg_py.__resvg_version__, str)


### PR DESCRIPTION
## Summary

Prepares 0.5.0 after the exception-safety and ABI/release-pipeline work landed, including user-facing Python 3.15 support. The tag guard fails before irreversible PyPI publication when the bare tag and Cargo package version differ; version-independent examples and the installed-metadata invariant avoid adding release-number copies that drift.

Renovate PR #173 remains independent so this release does not absorb an unrelated dependency refresh.

## Validation

- `uv run --no-sync pytest -p no:cacheprovider -q` — 41 passed, 1 skipped.
- `cargo fmt --all -- --check` and clippy with all targets/features passed.
- A release wheel reports version 0.5.0 and retains the existing baseplate-admin `Author-email` Core Metadata.
- Local positive and negative controls exercise the guard's exact-match comparison. The tag-triggered Release job is intentionally not exercised before the real 0.5.0 publication.
- Sphinx rendered all documentation; its existing missing `_static` warning remains unchanged.
- [Exact-head CI](https://github.com/baseplate-admin/resvg-py/actions/runs/32127177682) completed with 68 successful jobs and the tag-only Release job skipped.

Tagging and publication are intentionally excluded from this PR. After merge, the bare `0.5.0` tag will target the green merged `master` commit.
