### PR TITLE
ci: let the release job generate GitHub release notes

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -433,4 +433,5 @@ jobs:
         with:
           files: |
             wasm-wheels/*.whl
+          generate_release_notes: true
           prerelease: ${{ contains(github.ref, 'alpha') || contains(github.ref, 'beta') }}


### PR DESCRIPTION
0.5.0 shipped with the raw squash-commit message as its release body, unlike every release before it.

The cause is order of operations rather than the workflow. Releases up to 0.4.0 were drafted in the GitHub UI with **Generate release notes** and then published, which is what created the tag; by the time `softprops/action-gh-release` ran it found an existing release and left the body alone. 0.5.0 was tagged first, so the action created the release itself — and with no `body`, `body_path` or `generate_release_notes`, it falls back to the commit message.

Since #174 made the tag the thing that triggers a release, tag-first is the normal path now. `generate_release_notes: true` calls the same endpoint the UI button does, so notes come out in the existing format no matter who cuts the release or in which order.

0.5.0's body has already been regenerated by hand, so this only affects releases from here on.
