### PR TITLE
ci: publish to PyPI with a Trusted Publisher

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -425,9 +425,7 @@ jobs:
         uses: astral-sh/setup-uv@v10.0.1
       - name: Publish to PyPI
         if: ${{ startsWith(github.ref, 'refs/tags/') }}
-        run: uv publish 'wheels-*/*.whl' 'wheels-sdist/*.tar.gz'
-        env:
-          UV_PUBLISH_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+        run: uv publish --trusted-publishing always 'wheels-*/*.whl' 'wheels-sdist/*.tar.gz'
       - name: Upload to GitHub Release
         uses: softprops/action-gh-release@v3
         with:


### PR DESCRIPTION
Closes #179 — the publisher now exists on PyPI, so the job can stop sending `PYPI_API_TOKEN`.

It was registered with no environment name, so the job deliberately gains no `environment:` key; adding one would stop the OIDC claim from matching.
